### PR TITLE
Local mongo db

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,6 +36,7 @@ jobs:
             docker stop $CONTAINER_NAME $DB_CONTAINER_NAME || true
             docker rm $CONTAINER_NAME $DB_CONTAINER_NAME || true
             docker network rm $NETWORK_NAME || true
+            docker volume rm ${DB_CONTAINER_NAME}-data || true
 
 
             echo "Removing caddy snippet for port $PR_PORT."

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,7 +12,6 @@ on:
 jobs:
 
   cleanup_staging:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,13 +27,22 @@ jobs:
           script: |
             PR_PORT=$((5001 + ${{ github.event.pull_request.number }}))
             CONTAINER_NAME=${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-            echo "Removing $CONTAINER_NAME on port $PR_PORT"
-            docker stop $CONTAINER_NAME || true
-            docker rm $CONTAINER_NAME || true
+            DB_CONTAINER_NAME=${CONTAINER_NAME}-db
+            NETWORK_NAME=${CONTAINER_NAME}-net
+
+            echo "Cleaning up environment for PR #${{ github.event.pull_request.number }} on port $PR_PORT"
+
+            echo "Removing Docker artifacts"
+            docker stop $CONTAINER_NAME $DB_CONTAINER_NAME || true
+            docker rm $CONTAINER_NAME $DB_CONTAINER_NAME || true
+            docker network rm $NETWORK_NAME || true
+
+
             echo "Removing caddy snippet for port $PR_PORT."
-            mkdir -p "/etc/caddy/snippets/photographers_story_backend"
             rm "/etc/caddy/snippets/photographers_story_backend/${{ github.event.pull_request.number }}.caddy" || true
             caddy reload
+
+            echo "Cleanup for PR #${{ github.event.pull_request.number }} on port $PR_PORT complete"
 
   deploy_production:
     needs: cleanup_staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -100,6 +100,7 @@ jobs:
             docker run -d \
               --name $CONTAINER_NAME \
               --network $NETWORK_NAME \
+              -v ${DB_CONTAINER_NAME}-data:/data/db \
               -p $PR_PORT:8080 \
               -e "ASPNETCORE_ENVIRONMENT=Staging" \
               -e "MongoDbDatabase__ConnectionString=mongodb://${DB_CONTAINER_NAME}:27017" \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -72,16 +72,43 @@ jobs:
           script: |
             PR_PORT=$((5001 + ${{ github.event.pull_request.number }}))
             CONTAINER_NAME=${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-            echo "Running $CONTAINER_NAME on port $PR_PORT"
+            DB_CONTAINER_NAME=${CONTAINER_NAME}-db
+            NETWORK_NAME=${CONTAINER_NAME}-net
+
+            echo "Configuring environment for ${{ github.event.repository.name }} PR #${{ github.event.pull_request.number }} on port $PR_PORT"
+
+            # Get the latest API image from GHCR
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
             docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.event.pull_request.number }}
-            docker stop $CONTAINER_NAME || true
-            docker rm $CONTAINER_NAME || true
+
+            # Create a dedicated network for the PR
+            docker network create $NETWORK_NAME || true
+
+            # stop any existing containers
+            docker stop $CONTAINER_NAME $DB_CONTAINER_NAME || true
+            docker rm $CONTAINER_NAME $DB_CONTAINER_NAME || true
+
+            echo "Starting MongoDB container $DB_CONTAINER_NAME"
+            docker run -d \
+              --name $DB_CONTAINER_NAME \
+              --network $NETWORK_NAME \
+              --restart unless-stopped \
+              mongo:latest
+
+
+            echo "Starting API container $CONTAINER_NAME on port $PR_PORT"
             docker run -d \
               --name $CONTAINER_NAME \
+              --network $NETWORK_NAME \
               -p $PR_PORT:8080 \
+              -e "ASPNETCORE_ENVIRONMENT=Staging" \
+              -e "MongoDbDatabase__ConnectionString=mongodb://${DB_CONTAINER_NAME}:27017" \
+              -e "MongoDbDatabase__DatabaseName=${{ github.event.repository.name }}-${{ github.event.pull_request.number }}" \
+              --restart unless-stopped \
               ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.event.pull_request.number }}
+
             docker logout ghcr.io
+
             echo "Creating caddy snippet for port $PR_PORT."
             mkdir -p "/etc/caddy/snippets/photographers_story_backend"
             cat << EOF > "/etc/caddy/snippets/photographers_story_backend/${{ github.event.pull_request.number }}.caddy"
@@ -91,4 +118,7 @@ jobs:
               }
             }
             EOF
+
             caddy reload
+
+            echo "Deployment for PR #${{ github.event.pull_request.number }} on port $PR_PORT complete"

--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="9.0.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Database\Database.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Api/Controllers/HealthController.cs
+++ b/Api/Controllers/HealthController.cs
@@ -1,13 +1,16 @@
+// Api/Controllers/HealthController.cs
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers;
 
-[Route("api/Health")]
+[Route("health")]
 [ApiController]
 public class HealthController : ControllerBase
 {
     [HttpGet]
-    [EndpointSummary("A simple health check to make sure the server is online")]
+    [EndpointSummary("Server health check")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public IActionResult Get()
     {
         return NoContent();

--- a/Api/Controllers/PostsController.cs
+++ b/Api/Controllers/PostsController.cs
@@ -1,0 +1,120 @@
+using Microsoft.AspNetCore.Mvc;
+using Database.Interfaces;
+using Database.Models;
+
+namespace Api.Controllers;
+
+[Route("posts")]
+[ApiController]
+public class PostsController(IDatabaseService databaseService) : ControllerBase
+{
+    private readonly IDatabaseService _databaseService = databaseService;
+
+    /// <summary>
+    /// Retrieves all published posts from the database.
+    /// </summary>
+    /// <returns>A list of published posts.</returns>
+    [HttpGet("/published")]
+    [EndpointSummary("Get all published posts")]
+    [ProducesResponseType(typeof(IEnumerable<Post>), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/json")]
+    public async Task<IActionResult> GetPublishedPosts()
+    {
+        var posts = await _databaseService.GetPublishedPostsAsync();
+
+        if (posts.Count == 0)
+        {
+            return NotFound();
+        }
+
+        return Ok(posts);
+    }
+
+    /// <summary>
+    /// Gets a single post by its URL-friendly slug.
+    /// </summary>
+    /// <param name="slug">The slug of the post.</param>
+    /// <returns>The post, or a 404 Not Found if not found.</returns>
+    [HttpGet("{slug}")]
+    [EndpointSummary("Get a post by its slug")]
+    [ProducesResponseType(typeof(Post), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/json")]
+    public async Task<IActionResult> GetPostBySlug(string slug)
+    {
+        var post = await _databaseService.GetBySlugAsync(slug);
+
+        if (post == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(post);
+    }
+
+    /// <summary>
+    /// Creates a new post in the database.
+    /// </summary>
+    /// <param name="newPost">The post object to create.</param>
+    /// <returns>A 201 Created response.</returns>
+    [HttpPost]
+    [EndpointSummary("Create a new post")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/json")]
+    public async Task<IActionResult> CreatePost([FromBody] Post newPost)
+    {
+        await _databaseService.CreatePostAsync(newPost);
+        return CreatedAtAction(nameof(GetPostBySlug), new { slug = newPost.Slug }, newPost);
+    }
+
+    // TODO: make all the params optional and just overwrite the ones provided
+    /// <summary>
+    /// Updates an existing post.
+    /// </summary>
+    /// <param name="id">The ID of the post to update.</param>
+    /// <param name="updatedPost">The updated post object.</param>
+    /// <returns>A 204 No Content response if successful.</returns>
+    [HttpPut("{id}")]
+    [EndpointSummary("Update a post")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/json")]
+    public async Task<IActionResult> UpdatePost(string id, [FromBody] Post updatedPost)
+    {
+        await _databaseService.UpdatePostAsync(id, updatedPost);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Increments the view count for a specific post.
+    /// </summary>
+    /// <param name="id">The ID of the post.</param>
+    /// <returns>A 204 No Content response.</returns>
+    [HttpPut("{id}/views")]
+    [EndpointSummary("Increment a post's view count")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> IncrementViewCount(string id)
+    {
+        await _databaseService.IncrementViewCountAsync(id);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Retrieves posts that have a specific tag.
+    /// </summary>
+    /// <param name="tag">The tag to search for.</param>
+    /// <returns>A list of posts with the given tag.</returns>
+    [HttpGet("tagged/{tag}")]
+    [EndpointSummary("Get posts by tag")]
+    [ProducesResponseType(typeof(IEnumerable<Post>), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/json")]
+    public async Task<IActionResult> GetPostsByTag(string tag)
+    {
+        var posts = await _databaseService.GetPostsByTagAsync(tag);
+
+        if (posts.Count == 0)
+        {
+            return NotFound();
+        }
+
+        return Ok(posts);
+    }
+}

--- a/Api/Controllers/PostsController.cs
+++ b/Api/Controllers/PostsController.cs
@@ -1,3 +1,5 @@
+// Api/Controllers/PostsController.cs
+
 using Microsoft.AspNetCore.Mvc;
 using Database.Interfaces;
 using Database.Models;

--- a/Api/Controllers/PostsController.cs
+++ b/Api/Controllers/PostsController.cs
@@ -69,6 +69,7 @@ public class PostsController(IDatabaseService databaseService) : ControllerBase
     }
 
     // TODO: make all the params optional and just overwrite the ones provided
+    // TODO: handle not found post ids
     /// <summary>
     /// Updates an existing post.
     /// </summary>

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -9,6 +9,7 @@ using System.Net; // IP address parser
 using Database.Mongo.Services;
 using Database.Connection;
 using Microsoft.Extensions.Options;
+using Database.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,7 +43,7 @@ if (builder.Environment.IsDevelopment())
     );
 
     // Register the MongoDbService as a singleton, injecting the settings
-    builder.Services.AddSingleton(sp =>
+    builder.Services.AddSingleton<IDatabaseService>(sp =>
     {
         var settings = sp.GetRequiredService<IOptions<Mongo>>().Value;
         return new Posts(settings.ConnectionString, settings.DatabaseName);

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddControllers();
 builder.Services.AddOpenApi();
 
 // Conditionally configure the database service based on the environment
-if (builder.Environment.IsDevelopment())
+if (builder.Environment.IsDevelopment() || builder.Environment.IsStaging())
 {
     // Bind the MongoDbDatabase section of appsettings.json to the settings class
     builder.Services.Configure<Mongo>(

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -1,4 +1,4 @@
-// Program.cs
+// Api/Program.cs
 
 // article about OpenAPI admin panels
 // https://timdeschryver.dev/blog/what-about-my-api-documentation-now-that-swashbuckle-is-no-longer-a-dependency-in-aspnet-9
@@ -6,6 +6,9 @@
 using Scalar.AspNetCore;
 using Microsoft.AspNetCore.HttpOverrides;
 using System.Net; // IP address parser
+using Database.Mongo.Services;
+using Database.Connection;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,6 +32,22 @@ builder.Services.AddOutputCache(options =>
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+// Conditionally configure the database service based on the environment
+if (builder.Environment.IsDevelopment())
+{
+    // Bind the MongoDbDatabase section of appsettings.json to the settings class
+    builder.Services.Configure<Mongo>(
+        builder.Configuration.GetSection("MongoDbDatabase")
+    );
+
+    // Register the MongoDbService as a singleton, injecting the settings
+    builder.Services.AddSingleton(sp =>
+    {
+        var settings = sp.GetRequiredService<IOptions<Mongo>>().Value;
+        return new Posts(settings.ConnectionString, settings.DatabaseName);
+    });
+}
 
 var app = builder.Build();
 

--- a/Api/appsettings.Development.json
+++ b/Api/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "MongoDbDatabase": {
+    "ConnectionString": "mongodb://localhost:5002",
+    "DatabaseName": "PhotographersStory"
   }
 }

--- a/Database/Connection.cs
+++ b/Database/Connection.cs
@@ -1,0 +1,12 @@
+// Database/Connection.cs
+
+namespace Database.Connection;
+
+/// <summary>
+/// Settings for the MongoDB database connection, to be loaded from configuration.
+/// </summary>
+public class Mongo
+{
+    public string ConnectionString { get; set; } = null!;
+    public string DatabaseName { get; set; } = null!;
+}

--- a/Database/Connection.cs
+++ b/Database/Connection.cs
@@ -7,6 +7,6 @@ namespace Database.Connection;
 /// </summary>
 public class Mongo
 {
-    public string ConnectionString { get; set; } = null!;
-    public string DatabaseName { get; set; } = null!;
+    public required string ConnectionString { get; set; }
+    public required string DatabaseName { get; set; }
 }

--- a/Database/Database.csproj
+++ b/Database/Database.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="3.4.3" />
+  </ItemGroup>
+
+</Project>

--- a/Database/IDatabaseService.cs
+++ b/Database/IDatabaseService.cs
@@ -48,4 +48,6 @@ public interface IDatabaseService
     /// <param name="tag">The tag to search for.</param>
     /// <returns>A list of posts with the given tag.</returns>
     Task<List<Post>> GetPostsByTagAsync(string tag);
+
+    // TODO: add publish and unpublish methods
 }

--- a/Database/IDatabaseService.cs
+++ b/Database/IDatabaseService.cs
@@ -1,0 +1,51 @@
+﻿// Database/IDatabaseService.cs
+
+using Database.Models;
+
+namespace Database.Interfaces;
+
+/// <summary>
+/// Defines the contract for all database-related operations,
+/// abstracting away the underlying data store technology.
+/// </summary>
+public interface IDatabaseService
+{
+    /// <summary>
+    /// Retrieves all published posts from the database.
+    /// </summary>
+    /// <returns>A list of published posts.</returns>
+    Task<List<Post>> GetPublishedPostsAsync();
+
+    /// <summary>
+    /// Gets a single post by its slug.
+    /// </summary>
+    /// <param name="slug">The URL-friendly slug of the post.</param>
+    /// <returns>The post, or null if not found.</returns>
+    Task<Post?> GetBySlugAsync(string slug);
+
+    /// <summary>
+    /// Creates a new post in the database.
+    /// </summary>
+    /// <param name="newPost">The post to create.</param>
+    Task CreatePostAsync(Post newPost);
+
+    /// <summary>
+    /// Updates an existing post.
+    /// </summary>
+    /// <param name="id">The ID of the post to update.</param>
+    /// <param name="updatedPost">The updated post object.</param>
+    Task UpdatePostAsync(string id, Post updatedPost);
+
+    /// <summary>
+    /// Increments the view count for a specific post.
+    /// </summary>
+    /// <param name="id">The ID of the post.</param>
+    Task IncrementViewCountAsync(string id);
+
+    /// <summary>
+    /// Gets posts by a specific tag.
+    /// </summary>
+    /// <param name="tag">The tag to search for.</param>
+    /// <returns>A list of posts with the given tag.</returns>
+    Task<List<Post>> GetPostsByTagAsync(string tag);
+}

--- a/Database/Models/Location.cs
+++ b/Database/Models/Location.cs
@@ -5,8 +5,8 @@ namespace Database.Models;
 
 public class Location
 {
-    public string? Id { get; set; }
+    public required string Id { get; set; }
     public required string Place { get; set; }
-    public double Latitude { get; set; }
-    public double Longitude { get; set; }
+    public required double Latitude { get; set; }
+    public required double Longitude { get; set; }
 }

--- a/Database/Models/Location.cs
+++ b/Database/Models/Location.cs
@@ -1,0 +1,12 @@
+// Database/Models/Location.cs
+
+
+namespace Database.Models;
+
+public class Location
+{
+    public string? Id { get; set; }
+    public required string Place { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}

--- a/Database/Models/Photo.cs
+++ b/Database/Models/Photo.cs
@@ -7,6 +7,6 @@ public class Photo
     public required string Id { get; set; }
     public required string AltText { get; set; }
     public required string PublicUrl { get; set; }
-    public uint Width { get; set; }
-    public uint Height { get; set; }
+    public required uint Width { get; set; }
+    public required uint Height { get; set; }
 }

--- a/Database/Models/Photo.cs
+++ b/Database/Models/Photo.cs
@@ -1,0 +1,12 @@
+// Database/Models/Photo.cs
+
+namespace Database.Models;
+
+public class Photo
+{
+    public required string Id { get; set; }
+    public required string AltText { get; set; }
+    public required string PublicUrl { get; set; }
+    public uint Width { get; set; }
+    public uint Height { get; set; }
+}

--- a/Database/Models/Post.cs
+++ b/Database/Models/Post.cs
@@ -6,12 +6,12 @@ public class Post
 {
     public required string Id { get; set; }
     public required string Slug { get; set; }
-    public List<string> Tags { get; set; } = new List<string>();
+    public List<string> Tags { get; set; } = [];
     public required string Author { get; set; }
     public required string Title { get; set; }
     public required string Summary { get; set; }
     public Photo? CoverPhoto { get; set; }
-    public List<Photo> Photos { get; set; } = new List<Photo>();
+    public List<Photo> Photos { get; set; } = [];
     public required string ArticleContent { get; set; } // as markdown
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? EditedAt { get; set; }

--- a/Database/Models/Post.cs
+++ b/Database/Models/Post.cs
@@ -13,10 +13,10 @@ public class Post
     public Photo? CoverPhoto { get; set; }
     public List<Photo> Photos { get; set; } = [];
     public required string ArticleContent { get; set; } // as markdown
-    public required DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? EditedAt { get; set; }
     public DateTime? PublishedAt { get; set; } // null value indicates the post has not yet been published
-    public required uint ViewCount { get; set; } = 0;
+    public uint ViewCount { get; set; } = 0;
     public required Location Location { get; set; }
     public required uint ReadTimeMinutes { get; set; } = 0;
 }

--- a/Database/Models/Post.cs
+++ b/Database/Models/Post.cs
@@ -1,0 +1,22 @@
+// Database/Models/Post.cs
+
+namespace Database.Models;
+
+public class Post
+{
+    public required string Id { get; set; }
+    public required string Slug { get; set; }
+    public List<string> Tags { get; set; } = new List<string>();
+    public required string Author { get; set; }
+    public required string Title { get; set; }
+    public required string Summary { get; set; }
+    public Photo? CoverPhoto { get; set; }
+    public List<Photo> Photos { get; set; } = new List<Photo>();
+    public required string ArticleContent { get; set; } // as markdown
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? EditedAt { get; set; }
+    public DateTime? PublishedAt { get; set; } // null value indicates the post has not yet been published
+    public int ViewCount { get; set; } = 0;
+    public required Location Location { get; set; }
+    public int ReadTimeMinutes { get; set; } = 0;
+}

--- a/Database/Models/Post.cs
+++ b/Database/Models/Post.cs
@@ -13,10 +13,10 @@ public class Post
     public Photo? CoverPhoto { get; set; }
     public List<Photo> Photos { get; set; } = [];
     public required string ArticleContent { get; set; } // as markdown
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public required DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? EditedAt { get; set; }
     public DateTime? PublishedAt { get; set; } // null value indicates the post has not yet been published
-    public int ViewCount { get; set; } = 0;
+    public required uint ViewCount { get; set; } = 0;
     public required Location Location { get; set; }
-    public int ReadTimeMinutes { get; set; } = 0;
+    public required uint ReadTimeMinutes { get; set; } = 0;
 }

--- a/Database/Mongo/Models/Location.cs
+++ b/Database/Mongo/Models/Location.cs
@@ -1,0 +1,23 @@
+// Database/Mongo/Models/Location.cs
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Database.Mongo.Models;
+
+public class Location
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? Id { get; set; }
+    
+    // friendly name for the location
+    [BsonElement("place")]
+    public required string Place { get; set; }
+
+    [BsonElement("latitude")]
+    public double Latitude { get; set; }
+
+    [BsonElement("longitude")]
+    public double Longitude { get; set; }
+}

--- a/Database/Mongo/Models/Location.cs
+++ b/Database/Mongo/Models/Location.cs
@@ -10,7 +10,7 @@ public class Location
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
     public string? Id { get; set; }
-    
+
     // friendly name for the location
     [BsonElement("place")]
     public required string Place { get; set; }
@@ -20,4 +20,32 @@ public class Location
 
     [BsonElement("longitude")]
     public double Longitude { get; set; }
+
+    /// <summary>
+    /// Maps a core Location model to this MongoDB-specific model.
+    /// </summary>
+    public static Location FromCore(Database.Models.Location coreLocation)
+    {
+        return new Location
+        {
+            Id = coreLocation.Id,
+            Place = coreLocation.Place,
+            Latitude = coreLocation.Latitude,
+            Longitude = coreLocation.Longitude
+        };
+    }
+
+    /// <summary>
+    /// Maps this MongoDB-specific model to a core Location model.
+    /// </summary>
+    public Database.Models.Location ToCore()
+    {
+        return new Database.Models.Location
+        {
+            Id = Id,
+            Place = Place,
+            Latitude = Latitude,
+            Longitude = Longitude
+        };
+    }
 }

--- a/Database/Mongo/Models/Location.cs
+++ b/Database/Mongo/Models/Location.cs
@@ -9,7 +9,7 @@ public class Location
 {
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
-    public string? Id { get; set; }
+    public required string Id { get; set; }
 
     // friendly name for the location
     [BsonElement("place")]

--- a/Database/Mongo/Models/Photo.cs
+++ b/Database/Mongo/Models/Photo.cs
@@ -18,8 +18,38 @@ public class Photo
     public required string PublicUrl { get; set; }
 
     [BsonElement("width")]
-    public int Width { get; set; }
+    public uint Width { get; set; }
 
     [BsonElement("height")]
-    public int Height { get; set; }
+    public uint Height { get; set; }
+
+    /// <summary>
+    /// Maps a core Photo model to this MongoDB-specific model.
+    /// </summary>
+    public static Photo FromCore(Database.Models.Photo corePhoto)
+    {
+        return new Photo
+        {
+            Id = corePhoto.Id,
+            AltText = corePhoto.AltText,
+            PublicUrl = corePhoto.PublicUrl,
+            Width = corePhoto.Width,
+            Height = corePhoto.Height
+        };
+    }
+
+    /// <summary>
+    /// Maps this MongoDB-specific model to a core Photo model.
+    /// </summary>
+    public Database.Models.Photo ToCore()
+    {
+        return new Database.Models.Photo
+        {
+            Id = Id,
+            AltText = AltText,
+            PublicUrl = PublicUrl,
+            Width = Width,
+            Height = Height
+        };
+    }
 }

--- a/Database/Mongo/Models/Photo.cs
+++ b/Database/Mongo/Models/Photo.cs
@@ -1,0 +1,25 @@
+// Database/Mongo/Models/Photo.cs
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Database.Mongo.Models;
+
+public class Photo
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public required string Id { get; set; }
+
+    [BsonElement("alt_text")]
+    public required string AltText { get; set; }
+
+    [BsonElement("public_url")]
+    public required string PublicUrl { get; set; }
+
+    [BsonElement("width")]
+    public int Width { get; set; }
+
+    [BsonElement("height")]
+    public int Height { get; set; }
+}

--- a/Database/Mongo/Models/Post.cs
+++ b/Database/Mongo/Models/Post.cs
@@ -1,0 +1,62 @@
+// Database/Mongo/Models/Post.cs
+
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Database.Mongo.Models;
+
+public class Post
+{
+    // string in C# but stored as an ObjectId in Mongo
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public required string Id { get; set; }
+
+    // URL-friendly
+    [BsonElement("slug")]
+    public required string Slug { get; set; }
+
+    [BsonElement("tags")]
+    public List<string> Tags { get; set; } = new List<string>();
+
+    [BsonElement("author")]
+    public required string Author { get; set; }
+
+    [BsonElement("title")]
+    public required string Title { get; set; }
+
+    [BsonElement("summary")]
+    public required string Summary { get; set; }
+
+    [BsonElement("cover_photo")]
+    public Photo? CoverPhoto { get; set; }
+
+    [BsonElement("photos")]
+    public List<Photo> Photos { get; set; } = new List<Photo>();
+
+    // as markdown
+    [BsonElement("article_content")]
+    public required string ArticleContent { get; set; }
+
+    [BsonElement("created_at")]
+    [BsonRepresentation(BsonType.DateTime)]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [BsonElement("edited_at")]
+    [BsonRepresentation(BsonType.DateTime)]
+    public DateTime? EditedAt { get; set; }
+
+    // null value indicates the post has not yet been published
+    [BsonElement("published_at")]
+    [BsonRepresentation(BsonType.DateTime)]
+    public DateTime? PublishedAt { get; set; }
+
+    [BsonElement("view_count")]
+    public int ViewCount { get; set; } = 0;
+
+    [BsonElement("location")]
+    public required Location Location { get; set; }
+
+    [BsonElement("read_time_minutes")]
+    public int ReadTimeMinutes { get; set; } = 0;
+}

--- a/Database/Mongo/Models/Post.cs
+++ b/Database/Mongo/Models/Post.cs
@@ -52,13 +52,13 @@ public class Post
     public DateTime? PublishedAt { get; set; }
 
     [BsonElement("view_count")]
-    public int ViewCount { get; set; } = 0;
+    public uint ViewCount { get; set; } = 0;
 
     [BsonElement("location")]
     public required Location Location { get; set; }
 
     [BsonElement("read_time_minutes")]
-    public int ReadTimeMinutes { get; set; } = 0;
+    public uint ReadTimeMinutes { get; set; } = 0;
 
     /// <summary>
     /// Maps a core Post model to this MongoDB-specific model.

--- a/Database/Mongo/Models/Post.cs
+++ b/Database/Mongo/Models/Post.cs
@@ -17,7 +17,7 @@ public class Post
     public required string Slug { get; set; }
 
     [BsonElement("tags")]
-    public List<string> Tags { get; set; } = new List<string>();
+    public List<string> Tags { get; set; } = [];
 
     [BsonElement("author")]
     public required string Author { get; set; }
@@ -32,7 +32,7 @@ public class Post
     public Photo? CoverPhoto { get; set; }
 
     [BsonElement("photos")]
-    public List<Photo> Photos { get; set; } = new List<Photo>();
+    public List<Photo> Photos { get; set; } = [];
 
     // as markdown
     [BsonElement("article_content")]
@@ -59,4 +59,54 @@ public class Post
 
     [BsonElement("read_time_minutes")]
     public int ReadTimeMinutes { get; set; } = 0;
+
+    /// <summary>
+    /// Maps a core Post model to this MongoDB-specific model.
+    /// </summary>
+    public static Post FromCore(Database.Models.Post corePost)
+    {
+        return new Post
+        {
+            Id = corePost.Id,
+            Slug = corePost.Slug,
+            Tags = corePost.Tags,
+            Author = corePost.Author,
+            Title = corePost.Title,
+            Summary = corePost.Summary,
+            CoverPhoto = corePost.CoverPhoto != null ? Photo.FromCore(corePost.CoverPhoto) : null,
+            Photos = [.. corePost.Photos.Select(Photo.FromCore)],
+            ArticleContent = corePost.ArticleContent,
+            CreatedAt = corePost.CreatedAt,
+            EditedAt = corePost.EditedAt,
+            PublishedAt = corePost.PublishedAt,
+            ViewCount = corePost.ViewCount,
+            Location = Location.FromCore(corePost.Location),
+            ReadTimeMinutes = corePost.ReadTimeMinutes
+        };
+    }
+
+    /// <summary>
+    /// Maps this MongoDB-specific model to a core Post model.
+    /// </summary>
+    public Database.Models.Post ToCore()
+    {
+        return new Database.Models.Post
+        {
+            Id = Id,
+            Slug = Slug,
+            Tags = Tags,
+            Author = Author,
+            Title = Title,
+            Summary = Summary,
+            CoverPhoto = CoverPhoto?.ToCore(),
+            Photos = [.. Photos.Select(p => p.ToCore())],
+            ArticleContent = ArticleContent,
+            CreatedAt = CreatedAt,
+            EditedAt = EditedAt,
+            PublishedAt = PublishedAt,
+            ViewCount = ViewCount,
+            Location = Location.ToCore(),
+            ReadTimeMinutes = ReadTimeMinutes
+        };
+    }
 }

--- a/Database/Mongo/Service.cs
+++ b/Database/Mongo/Service.cs
@@ -5,16 +5,14 @@ using Database.Interfaces;
 
 namespace Database.Mongo.Services;
 
-public class Posts : IDatabaseService
+public class Posts(IMongoCollection<Models.Post> postsCollection) : IDatabaseService
 {
-    private readonly IMongoCollection<Models.Post> _postsCollection;
+    private readonly IMongoCollection<Models.Post> _postsCollection = postsCollection;
 
-    public Posts(string connectionString, string databaseName)
-    {
-        var client = new MongoClient(connectionString);
-        var database = client.GetDatabase(databaseName);
-        _postsCollection = database.GetCollection<Models.Post>("posts");
-    }
+    public Posts(string connectionString, string databaseName) : this(
+        new MongoClient(connectionString).GetDatabase(databaseName).GetCollection<Models.Post>("posts")
+    )
+    { }
 
     /// <inheritdoc />
     public async Task<List<Database.Models.Post>> GetPublishedPostsAsync()

--- a/Database/Mongo/Service.cs
+++ b/Database/Mongo/Service.cs
@@ -28,7 +28,10 @@ public class Posts : IDatabaseService
     public async Task<Database.Models.Post?> GetBySlugAsync(string slug)
     {
         var filter = Builders<Models.Post>.Filter.Eq(p => p.Slug, slug);
-        var mongoPost = await _postsCollection.Find(filter).FirstOrDefaultAsync();
+        var filter2 = Builders<Models.Post>.Filter.Ne(p => p.PublishedAt, null);
+        var combinedFilter = Builders<Models.Post>.Filter.And(filter, filter2);
+
+        var mongoPost = await _postsCollection.Find(combinedFilter).FirstOrDefaultAsync();
         return mongoPost?.ToCore();
     }
 
@@ -50,7 +53,7 @@ public class Posts : IDatabaseService
     public async Task IncrementViewCountAsync(string id)
     {
         var filter = Builders<Models.Post>.Filter.Eq(p => p.Id, id);
-        var update = Builders<Models.Post>.Update.Inc(p => p.ViewCount, 1);
+        var update = Builders<Models.Post>.Update.Inc("ViewCount", 1);
         await _postsCollection.UpdateOneAsync(filter, update);
     }
 
@@ -58,7 +61,9 @@ public class Posts : IDatabaseService
     public async Task<List<Database.Models.Post>> GetPostsByTagAsync(string tag)
     {
         var filter = Builders<Models.Post>.Filter.AnyEq(p => p.Tags, tag);
-        var mongoPosts = await _postsCollection.Find(filter).ToListAsync();
+        var filter2 = Builders<Models.Post>.Filter.Ne(p => p.PublishedAt, null);
+        var combinedFilter = Builders<Models.Post>.Filter.And(filter, filter2);
+        var mongoPosts = await _postsCollection.Find(combinedFilter).ToListAsync();
         return [.. mongoPosts.Select(p => p.ToCore())];
     }
 }

--- a/Database/Mongo/Service.cs
+++ b/Database/Mongo/Service.cs
@@ -1,90 +1,64 @@
 // Database/Mongo/Service.cs
 
 using MongoDB.Driver;
-using Database.Mongo.Models;
+using Database.Interfaces;
 
 namespace Database.Mongo.Services;
 
-public class Posts
+public class Posts : IDatabaseService
 {
-    private readonly IMongoCollection<Post> _postsCollection;
+    private readonly IMongoCollection<Models.Post> _postsCollection;
 
     public Posts(string connectionString, string databaseName)
     {
         var client = new MongoClient(connectionString);
         var database = client.GetDatabase(databaseName);
-        _postsCollection = database.GetCollection<Post>("posts");
+        _postsCollection = database.GetCollection<Models.Post>("posts");
     }
 
-    /// <summary>
-    /// Retrieves all published posts from the database.
-    /// </summary>
-    /// <returns>A list of published posts.</returns>
-    public async Task<List<Post>> GetPublishedPostsAsync()
+    /// <inheritdoc />
+    public async Task<List<Database.Models.Post>> GetPublishedPostsAsync()
     {
-        var filter = Builders<Post>.Filter.Ne(p => p.PublishedAt, null);
-        return await _postsCollection.Find(filter).ToListAsync();
+        var filter = Builders<Models.Post>.Filter.Ne(p => p.PublishedAt, null);
+        var mongoPosts = await _postsCollection.Find(filter).ToListAsync();
+        return [.. mongoPosts.Select(p => p.ToCore())];
     }
 
-    /// <summary>
-    /// Gets a single post by its slug.
-    /// </summary>
-    /// <param name="slug">The URL-friendly slug of the post.</param>
-    /// <returns>The post, or null if not found.</returns>
-    public async Task<Post> GetBySlugAsync(string slug)
+    /// <inheritdoc />
+    public async Task<Database.Models.Post?> GetBySlugAsync(string slug)
     {
-        var filter = Builders<Post>.Filter.Eq(p => p.Slug, slug);
-        return await _postsCollection.Find(filter).FirstOrDefaultAsync();
+        var filter = Builders<Models.Post>.Filter.Eq(p => p.Slug, slug);
+        var mongoPost = await _postsCollection.Find(filter).FirstOrDefaultAsync();
+        return mongoPost?.ToCore();
     }
 
-    /// <summary>
-    /// Creates a new post in the database.
-    /// </summary>
-    /// <param name="newPost">The post to create.</param>
-    public async Task CreatePostAsync(Post newPost)
+    /// <inheritdoc />
+    public async Task CreatePostAsync(Database.Models.Post newPost)
     {
-        await _postsCollection.InsertOneAsync(newPost);
+        var mongoPost = Models.Post.FromCore(newPost);
+        await _postsCollection.InsertOneAsync(mongoPost);
     }
 
-    /// <summary>
-    /// Updates an existing post.
-    /// </summary>
-    /// <param name="id">The ID of the post to update.</param>
-    /// <param name="updatedPost">The updated post object.</param>
-    public async Task UpdatePostAsync(string id, Post updatedPost)
+    /// <inheritdoc />
+    public async Task UpdatePostAsync(string id, Database.Models.Post updatedPost)
     {
-        await _postsCollection.ReplaceOneAsync(p => p.Id == id, updatedPost);
+        var mongoPost = Models.Post.FromCore(updatedPost);
+        await _postsCollection.ReplaceOneAsync(p => p.Id == id, mongoPost);
     }
 
-    /// <summary>
-    /// Deletes a post from the database by its ID.
-    /// </summary>
-    /// <param name="id">The ID of the post to delete.</param>
-    public async Task DeletePostAsync(string id)
-    {
-        var filter = Builders<Post>.Filter.Eq(p => p.Id, id);
-        await _postsCollection.DeleteOneAsync(filter);
-    }
-
-    /// <summary>
-    /// Increments the view count for a specific post.
-    /// </summary>
-    /// <param name="id">The ID of the post.</param>
+    /// <inheritdoc />
     public async Task IncrementViewCountAsync(string id)
     {
-        var filter = Builders<Post>.Filter.Eq(p => p.Id, id);
-        var update = Builders<Post>.Update.Inc(p => p.ViewCount, 1);
+        var filter = Builders<Models.Post>.Filter.Eq(p => p.Id, id);
+        var update = Builders<Models.Post>.Update.Inc(p => p.ViewCount, 1);
         await _postsCollection.UpdateOneAsync(filter, update);
     }
 
-    /// <summary>
-    /// Gets posts by a specific tag.
-    /// </summary>
-    /// <param name="tag">The tag to search for.</param>
-    /// <returns>A list of posts with the given tag.</returns>
-    public async Task<List<Post>> GetPostsByTagAsync(string tag)
+    /// <inheritdoc />
+    public async Task<List<Database.Models.Post>> GetPostsByTagAsync(string tag)
     {
-        var filter = Builders<Post>.Filter.AnyEq(p => p.Tags, tag);
-        return await _postsCollection.Find(filter).ToListAsync();
+        var filter = Builders<Models.Post>.Filter.AnyEq(p => p.Tags, tag);
+        var mongoPosts = await _postsCollection.Find(filter).ToListAsync();
+        return [.. mongoPosts.Select(p => p.ToCore())];
     }
 }

--- a/Database/Mongo/Service.cs
+++ b/Database/Mongo/Service.cs
@@ -1,0 +1,90 @@
+// Database/Mongo/Service.cs
+
+using MongoDB.Driver;
+using Database.Mongo.Models;
+
+namespace Database.Mongo.Services;
+
+public class Posts
+{
+    private readonly IMongoCollection<Post> _postsCollection;
+
+    public Posts(string connectionString, string databaseName)
+    {
+        var client = new MongoClient(connectionString);
+        var database = client.GetDatabase(databaseName);
+        _postsCollection = database.GetCollection<Post>("posts");
+    }
+
+    /// <summary>
+    /// Retrieves all published posts from the database.
+    /// </summary>
+    /// <returns>A list of published posts.</returns>
+    public async Task<List<Post>> GetPublishedPostsAsync()
+    {
+        var filter = Builders<Post>.Filter.Ne(p => p.PublishedAt, null);
+        return await _postsCollection.Find(filter).ToListAsync();
+    }
+
+    /// <summary>
+    /// Gets a single post by its slug.
+    /// </summary>
+    /// <param name="slug">The URL-friendly slug of the post.</param>
+    /// <returns>The post, or null if not found.</returns>
+    public async Task<Post> GetBySlugAsync(string slug)
+    {
+        var filter = Builders<Post>.Filter.Eq(p => p.Slug, slug);
+        return await _postsCollection.Find(filter).FirstOrDefaultAsync();
+    }
+
+    /// <summary>
+    /// Creates a new post in the database.
+    /// </summary>
+    /// <param name="newPost">The post to create.</param>
+    public async Task CreatePostAsync(Post newPost)
+    {
+        await _postsCollection.InsertOneAsync(newPost);
+    }
+
+    /// <summary>
+    /// Updates an existing post.
+    /// </summary>
+    /// <param name="id">The ID of the post to update.</param>
+    /// <param name="updatedPost">The updated post object.</param>
+    public async Task UpdatePostAsync(string id, Post updatedPost)
+    {
+        await _postsCollection.ReplaceOneAsync(p => p.Id == id, updatedPost);
+    }
+
+    /// <summary>
+    /// Deletes a post from the database by its ID.
+    /// </summary>
+    /// <param name="id">The ID of the post to delete.</param>
+    public async Task DeletePostAsync(string id)
+    {
+        var filter = Builders<Post>.Filter.Eq(p => p.Id, id);
+        await _postsCollection.DeleteOneAsync(filter);
+    }
+
+    /// <summary>
+    /// Increments the view count for a specific post.
+    /// </summary>
+    /// <param name="id">The ID of the post.</param>
+    public async Task IncrementViewCountAsync(string id)
+    {
+        var filter = Builders<Post>.Filter.Eq(p => p.Id, id);
+        var update = Builders<Post>.Update.Inc(p => p.ViewCount, 1);
+        await _postsCollection.UpdateOneAsync(filter, update);
+    }
+
+    /// <summary>
+    /// Gets posts by a specific tag.
+    /// </summary>
+    /// <param name="tag">The tag to search for.</param>
+    /// <returns>A list of posts with the given tag.</returns>
+    public async Task<List<Post>> GetPostsByTagAsync(string tag)
+    {
+        var filter = Builders<Post>.Filter.AnyEq(p => p.Tags, tag);
+        return await _postsCollection.Find(filter).ToListAsync();
+    }
+}

--- a/Database/Mongo/docker-compose.yml
+++ b/Database/Mongo/docker-compose.yml
@@ -1,0 +1,15 @@
+# Database/Mongo/docker-compose.yml
+
+services:
+  database:
+    image: mongo:latest
+    container_name: photographers_story_db
+    ports:
+      - "5002:27017"
+    volumes:
+      - mongo_data:/data/db
+    restart: unless-stopped
+
+volumes:
+  mongo_data:
+    driver: local

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /src
 # This leverages Docker's layer caching to speed up builds if only source code changes.
 # The project file is located in the 'Api' directory within the solution.
 COPY ["Api/Api.csproj", "Api/"]
+COPY ["Database/Database.csproj", "Database/"]
 RUN dotnet restore "Api/Api.csproj"
 
 # Copy the entire solution's source code, including the Api and Tests projects.

--- a/Tests/Api/HealthController.cs
+++ b/Tests/Api/HealthController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
-namespace Tests;
+namespace Tests.Api;
 
 public class HealthControllerTests
 {
@@ -8,7 +8,8 @@ public class HealthControllerTests
     public void HealthCheck_Returns204_ForGetRequest()
     {
         // Arrange
-        var controller = new Api.Controllers.HealthController();
+        // avoid the namespace collision with the test namespace
+        var controller = new global::Api.Controllers.HealthController();
         
         // Act
         var result = controller.Get();

--- a/Tests/Api/PostsController.cs
+++ b/Tests/Api/PostsController.cs
@@ -1,0 +1,156 @@
+// Tests/PostsController.cs
+
+using Api.Controllers;
+using Database.Interfaces;
+using Database.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace Tests.Api;
+
+public class PostsControllerTests
+{
+    private readonly Mock<IDatabaseService> _mockDatabaseService;
+    private readonly PostsController _controller;
+
+    public PostsControllerTests()
+    {
+        _mockDatabaseService = new Mock<IDatabaseService>();
+        _controller = new PostsController(_mockDatabaseService.Object);
+    }
+
+    [Fact]
+    public async Task GetPublishedPosts_Returns_Ok_When_Posts_Exist()
+    {
+        // Arrange
+        var posts = new List<Post> { new Builders.PostBuilder().Build(), new Builders.PostBuilder().Build() };
+        _mockDatabaseService.Setup(s => s.GetPublishedPostsAsync()).ReturnsAsync(posts);
+
+        // Act
+        var result = await _controller.GetPublishedPosts();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedPosts = Assert.IsType<List<Post>>(okResult.Value);
+        Assert.Equal(posts.Count, returnedPosts.Count);
+    }
+
+    [Fact]
+    public async Task GetPublishedPosts_Returns_NotFound_When_No_Posts_Exist()
+    {
+        // Arrange
+        var posts = new List<Post>();
+        _mockDatabaseService.Setup(s => s.GetPublishedPostsAsync()).ReturnsAsync(posts);
+
+        // Act
+        var result = await _controller.GetPublishedPosts();
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPostBySlug_Returns_Ok_When_Post_Exists()
+    {
+        // Arrange
+        var slug = "test-post";
+        var post = new Builders.PostBuilder().WithSlug(slug).Build();
+        _mockDatabaseService.Setup(s => s.GetBySlugAsync(slug)).ReturnsAsync(post);
+
+        // Act
+        var result = await _controller.GetPostBySlug(slug);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedPost = Assert.IsType<Post>(okResult.Value);
+        Assert.Equal(slug, returnedPost.Slug);
+    }
+
+    [Fact]
+    public async Task GetPostBySlug_Returns_NotFound_When_Post_Does_Not_Exist()
+    {
+        // Arrange
+        var slug = "non-existent-post";
+        _mockDatabaseService.Setup(s => s.GetBySlugAsync(slug)).ReturnsAsync((Post?)null);
+
+        // Act
+        var result = await _controller.GetPostBySlug(slug);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task CreatePost_Returns_CreatedAt_When_Post_Created()
+    {
+        // Arrange
+        var post = new Builders.PostBuilder().Build();
+        _mockDatabaseService.Setup(s => s.CreatePostAsync(post)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.CreatePost(post);
+
+        // Assert
+        Assert.IsType<CreatedAtActionResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePost_Returns_NoContent_When_Post_Updated()
+    {
+        // Arrange
+        var post = new Builders.PostBuilder().Build();
+        _mockDatabaseService.Setup(s => s.UpdatePostAsync(post.Id, post)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.UpdatePost(post.Id, post);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task IncrementViewCount_Returns_NoContent_When_Count_Incremented()
+    {
+        // Arrange
+        var post = new Builders.PostBuilder().Build();
+        _mockDatabaseService.Setup(s => s.IncrementViewCountAsync(post.Id)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.IncrementViewCount(post.Id);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPostsByTag_Returns_Ok_When_Posts_Exist()
+    {
+        // Arrange
+        var tag = "test-tag";
+        var posts = new List<Post> { new Builders.PostBuilder().WithTags([tag]).Build() };
+        _mockDatabaseService.Setup(s => s.GetPostsByTagAsync(tag)).ReturnsAsync(posts);
+
+        // Act
+        var result = await _controller.GetPostsByTag(tag);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedPosts = Assert.IsType<List<Post>>(okResult.Value);
+        Assert.Equal(posts.Count, returnedPosts.Count);
+    }
+
+    [Fact]
+    public async Task GetPostsByTag_Returns_NotFound_When_No_Posts_Exist()
+    {
+        // Arrange
+        var tag = "non-existent-tag";
+        var posts = new List<Post>();
+        _mockDatabaseService.Setup(s => s.GetPostsByTagAsync(tag)).ReturnsAsync(posts);
+
+        // Act
+        var result = await _controller.GetPostsByTag(tag);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/Tests/Database/Builders/Core.cs
+++ b/Tests/Database/Builders/Core.cs
@@ -45,6 +45,12 @@ public class PostBuilder
         return this;
     }
 
+    public PostBuilder WithTags(List<string> tags)
+    {
+        _post.Tags = tags;
+        return this;
+    }
+
     public PostBuilder IsPublished()
     {
         _post.PublishedAt = DateTime.UtcNow;

--- a/Tests/Database/Builders/Core.cs
+++ b/Tests/Database/Builders/Core.cs
@@ -1,9 +1,9 @@
 // Tests/Database/Builders/Mongo.cs
 
-using Database.Mongo.Models;
+using Database.Models;
 using MongoDB.Bson;
 
-namespace Tests.Builders.Mongo;
+namespace Tests.Builders;
 
 public class PostBuilder
 {
@@ -28,7 +28,8 @@ public class PostBuilder
                 Latitude = 41.1561268114726,
                 Longitude = -81.41418385982185
             },
-            Summary = "A post for testing purposes"
+            Summary = "A post for testing purposes",
+            ReadTimeMinutes = 5
         };
     }
 

--- a/Tests/Database/Builders/Mongo.cs
+++ b/Tests/Database/Builders/Mongo.cs
@@ -1,0 +1,63 @@
+// Tests/Database/Builders/Mongo.cs
+
+using Database.Mongo.Models;
+using MongoDB.Bson;
+
+namespace Tests.Builders;
+
+public class PostBuilder
+{
+    private readonly Post _post;
+
+    public PostBuilder()
+    {
+        _post = new Post
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Title = "Default Test Post Title",
+            Slug = "default-test-post-slug",
+            ArticleContent = "This is the default post body.",
+            Author = "Test Person",
+            PublishedAt = null,
+            Tags = ["photography", "test"],
+            CreatedAt = DateTime.UtcNow,
+            Location = new Location
+            {
+                Id = "1",
+                Place = "Test City",
+                Latitude = 41.1561268114726,
+                Longitude = -81.41418385982185
+            },
+            Summary = "A post for testing purposes"
+        };
+    }
+
+    public PostBuilder WithTitle(string title)
+    {
+        _post.Title = title;
+        return this;
+    }
+
+    public PostBuilder WithSlug(string slug)
+    {
+        _post.Slug = slug;
+        return this;
+    }
+
+    public PostBuilder IsPublished()
+    {
+        _post.PublishedAt = DateTime.UtcNow;
+        return this;
+    }
+
+    public PostBuilder IsDraft()
+    {
+        _post.PublishedAt = null;
+        return this;
+    }
+
+    public Post Build()
+    {
+        return _post;
+    }
+}

--- a/Tests/Database/Mongo.cs
+++ b/Tests/Database/Mongo.cs
@@ -219,7 +219,6 @@ public class MongoPostsServiceTests
     public async Task UpdatePostAsync_Calls_ReplaceOneAsync()
     {
         // Arrange
-        var mockId = ObjectId.GenerateNewId().ToString();
         var mockPost = new Builders.PostBuilder().IsPublished().Build();
         var updatedMongoPost = Post.FromCore(mockPost);
 
@@ -231,13 +230,13 @@ public class MongoPostsServiceTests
         )).ReturnsAsync(new ReplaceOneResult.Acknowledged(1, 1, new BsonDocument())).Verifiable();
 
         // Act
-        await _service.UpdatePostAsync(mockId, mockPost);
+        await _service.UpdatePostAsync(mockPost.Id, mockPost);
 
         // Assert
         // Verify that ReplaceOneAsync was called once with the correct filter and updated object
         _mockCollection.Verify(c => c.ReplaceOneAsync(
             It.IsAny<FilterDefinition<Post>>(),
-            It.Is<Post>(p => p.Id == mockId && p.Title == mockPost.Title),
+            It.Is<Post>(p => p.Id == mockPost.Id && p.Title == mockPost.Title),
             It.IsAny<ReplaceOptions>(),
             It.IsAny<CancellationToken>()
         ), Times.Once);

--- a/Tests/Database/Mongo.cs
+++ b/Tests/Database/Mongo.cs
@@ -1,0 +1,394 @@
+using Moq;
+using MongoDB.Driver;
+using Database.Mongo.Services;
+using Database.Mongo.Models;
+using Tests.Builders;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace Tests.Database;
+
+// unit tests for the MongoDB Posts Service. They aren't supposed to test that
+// data in the database is appropriately handled, since that would be testing
+// the Mongo driver methods. Instead, we are testing that the correct methods
+// are being called by replacing the underlying "database" with mocks so that it
+// doesn't rely on an actual database running.
+
+// It should test different things based on the method it is testing:
+
+// assert return values when
+// - When your service method transforms, filters, or wraps data before returning.
+// - When your method has branching logic based on the mock’s return (e.g., return null if not found).
+
+// verify method calls when 
+// - When your method's purpose is to invoke a side effect (e.g., Insert, Update).
+// - When you want to ensure the right arguments were passed to the dependency.
+// - When your method doesn't return anything (void/Task) and just triggers actions.
+
+
+public class MongoPostsServiceTests
+{
+    private readonly Mock<IMongoCollection<Post>> _mockCollection;
+    private readonly Mock<IAsyncCursor<Post>> _mockCursor;
+    private readonly Posts _service;
+
+    public MongoPostsServiceTests()
+    {
+        // Set up the mocks
+        _mockCollection = new Mock<IMongoCollection<Post>>();
+        _mockCursor = new Mock<IAsyncCursor<Post>>();
+
+        // Configure the cursor mock to return a list of items and then signal the end of the collection
+        _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        // Instantiate the service using the mocked collection
+        _service = new Posts(_mockCollection.Object);
+    }
+
+    [Fact]
+    public async Task GetPublishedPostsAsync_Returns_OnlyPublishedPosts()
+    {
+        // Arrange
+        var publishedPost = new PostBuilder().IsPublished().Build();
+        var draftPost = new PostBuilder().IsDraft().Build();
+        var mockPosts = new List<Post> { publishedPost, draftPost };
+
+        // Configure the cursor mock to return our mock data
+        _mockCursor.Setup(_ => _.Current).Returns([publishedPost]);
+
+        // capture the filter used to test it
+        FilterDefinition<Post>? capturedFilter = null;
+
+        // Configure the collection mock to return our mock cursor when FindAsync is called
+        // We use It.IsAny<T> to make the test less brittle by not depending on the exact filter expression.
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).Callback((FilterDefinition<Post> filter, FindOptions<Post, Post> _, CancellationToken _) =>
+            {
+                capturedFilter = filter;
+            }).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetPublishedPostsAsync();
+
+        // Assert
+
+        // check the result
+        Assert.NotNull(result);
+        Assert.Single(result); // We should only get one post (the published one)
+        Assert.Equal(publishedPost.Slug, result[0].Slug);
+        Assert.NotNull(result[0].PublishedAt);
+
+        // check the filter
+        Assert.NotNull(capturedFilter);
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<Post>();
+        var renderedFilter = capturedFilter.Render(new RenderArgs<Post>(serializer, BsonSerializer.SerializerRegistry));
+
+        // Check that the filter contains the correct conditions
+        Assert.True(renderedFilter.Contains("published_at"));
+        Assert.Equal(BsonNull.Value, renderedFilter["published_at"].AsBsonDocument["$ne"]);
+
+    }
+
+    [Fact]
+    public async Task GetBySlugAsync_Returns_CorrectPost()
+    {
+        // Arrange
+        var expectedSlug = "published-post-slug";
+        var mockPost = new PostBuilder().IsPublished().WithSlug(expectedSlug).Build();
+        _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+        _mockCursor.Setup(_ => _.Current).Returns([mockPost]);
+
+        FilterDefinition<Post>? capturedFilter = null;
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).Callback((FilterDefinition<Post> filter, FindOptions<Post, Post> _, CancellationToken _) =>
+    {
+        capturedFilter = filter;
+    }).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetBySlugAsync(expectedSlug);
+
+        // Assert
+
+        // test the result
+        Assert.NotNull(result);
+        Assert.Equal(expectedSlug, result.Slug);
+        Assert.NotNull(result.PublishedAt); // A post fetched by slug should also be published
+
+        // test the filter
+        Assert.NotNull(capturedFilter);
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<Post>();
+        var renderedFilter = capturedFilter.Render(new RenderArgs<Post>(serializer, BsonSerializer.SerializerRegistry));
+
+        // Check that the filter contains the correct conditions
+        Assert.Equal(expectedSlug, renderedFilter["slug"].AsString);
+        Assert.True(renderedFilter.Contains("published_at"));
+        Assert.Equal(BsonNull.Value, renderedFilter["published_at"].AsBsonDocument["$ne"]);
+    }
+
+    [Fact]
+    public async Task GetBySlugAsync_Returns_NullForNonExistentPost()
+    {
+        // Arrange
+        var slug = "draft-post";
+        var draftPost = new PostBuilder().IsDraft().WithSlug(slug).Build();
+        // We configure the mock cursor to return no data
+        _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockCursor.Setup(_ => _.Current).Returns([]);
+
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetBySlugAsync("non-existent-slug");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetBySlugAsync_Returns_NullForNonPublishedPost()
+    {
+        // Arrange
+        var expectedSlug = "unpublished-post-slug";
+
+        // We now configure the mock to return the post that would be found
+        // by the database query before the service's logic filters it.
+        _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+        _mockCursor.Setup(_ => _.Current).Returns([]);
+
+        // This setup will cause the Find operation to "find" the mockPost
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetBySlugAsync(expectedSlug);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreatePostAsync_Calls_InsertOneAsync()
+    {
+        // Arrange
+        var mockPost = new global::Database.Models.Post
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            ArticleContent = "Test content",
+            Author = "Test Author",
+            Location = new global::Database.Models.Location
+            {
+                Id = ObjectId.GenerateNewId().ToString(),
+                Place = "Test City",
+                Latitude = 41.1561268114726,
+                Longitude = -81.41418385982185
+            },
+            ReadTimeMinutes = 5,
+            Slug = "test-title",
+            Summary = "Made to test the mongo service",
+            Title = "Test Title"
+        };
+        var mongoPost = Post.FromCore(mockPost);
+
+        // Configure the mock to do nothing when InsertOneAsync is called
+        _mockCollection.Setup(c => c.InsertOneAsync(
+            It.IsAny<Post>(),
+            It.IsAny<InsertOneOptions>(),
+            It.IsAny<CancellationToken>()
+        )).Returns(Task.CompletedTask).Verifiable();
+
+        // Act
+        await _service.CreatePostAsync(mockPost);
+
+        // Assert
+        // Verify that the InsertOneAsync method was called exactly once with a post object
+        _mockCollection.Verify(c => c.InsertOneAsync(
+            It.Is<Post>(p => p.Slug == mongoPost.Slug),
+            It.IsAny<InsertOneOptions>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePostAsync_Calls_ReplaceOneAsync()
+    {
+        // Arrange
+        var mockId = ObjectId.GenerateNewId().ToString();
+        var mockPost = new global::Database.Models.Post
+        {
+            Id = mockId,
+            ArticleContent = "Test content",
+            Author = "Test Author",
+            Location = new global::Database.Models.Location
+            {
+                Id = ObjectId.GenerateNewId().ToString(),
+                Place = "Test City",
+                Latitude = 41.1561268114726,
+                Longitude = -81.41418385982185
+            },
+            ReadTimeMinutes = 5,
+            Slug = "test-title",
+            Summary = "Made to test the mongo service",
+            Title = "Test Title"
+        };
+        var updatedMongoPost = Post.FromCore(mockPost);
+
+        _mockCollection.Setup(c => c.ReplaceOneAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<Post>(),
+            It.IsAny<ReplaceOptions>(),
+            It.IsAny<CancellationToken>()
+        )).ReturnsAsync(new ReplaceOneResult.Acknowledged(1, 1, new BsonDocument())).Verifiable();
+
+        // Act
+        await _service.UpdatePostAsync(mockId, mockPost);
+
+        // Assert
+        // Verify that ReplaceOneAsync was called once with the correct filter and updated object
+        _mockCollection.Verify(c => c.ReplaceOneAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.Is<Post>(p => p.Id == mockId && p.Title == mockPost.Title),
+            It.IsAny<ReplaceOptions>(),
+            It.IsAny<CancellationToken>()
+        ), Times.Once);
+    }
+
+    [Fact]
+    public async Task IncrementViewCountAsync_Calls_UpdateOneAsync()
+    {
+        // Arrange
+        var postId = ObjectId.GenerateNewId().ToString();
+        FilterDefinition<Post>? capturedFilter = null;
+        UpdateDefinition<Post>? capturedUpdate = null;
+
+        _mockCollection.Setup(c => c.UpdateOneAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<UpdateDefinition<Post>>(),
+            It.IsAny<UpdateOptions>(),
+            It.IsAny<CancellationToken>()
+        )).Callback((
+            FilterDefinition<Post> filter,
+            UpdateDefinition<Post> update,
+            UpdateOptions _,
+            CancellationToken __
+        ) =>
+        {
+            capturedFilter = filter;
+            capturedUpdate = update;
+        }).ReturnsAsync(new UpdateResult.Acknowledged(1, 1, null));
+
+        // Act
+        await _service.IncrementViewCountAsync(postId);
+
+        // Assert
+        Assert.NotNull(capturedFilter);
+        Assert.NotNull(capturedUpdate);
+
+
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<Post>();
+        var renderedFilter = capturedFilter.Render(new RenderArgs<Post>(serializer, BsonSerializer.SerializerRegistry));
+        Assert.Equal(postId, renderedFilter["_id"].ToString());
+
+        var renderedUpdate = capturedUpdate.Render(new RenderArgs<Post>(serializer, BsonSerializer.SerializerRegistry));
+
+        var incDocument = renderedUpdate["$inc"].AsBsonDocument;
+        Assert.True(incDocument.Contains("view_count"));
+        Assert.Equal(1, incDocument["view_count"].AsInt32);
+    }
+
+    [Fact]
+    public async Task GetPostsByTagAsync_Returns_CorrectPosts()
+    {
+        // Arrange
+        var tag = "photography";
+        var postWithTag = new PostBuilder().IsPublished().Build();
+        var anotherPostWithTag = new PostBuilder().IsPublished().WithSlug("another-post").Build();
+        var postWithoutTag = new PostBuilder().IsPublished().WithSlug("no-tag-post").Build(); // This one should be filtered out
+        var unpublishedPostWithTag = new PostBuilder().IsDraft().WithSlug("unpublished-post").Build(); // This one should be filtered out
+        postWithTag.Tags.Add(tag);
+        anotherPostWithTag.Tags.Add(tag);
+        unpublishedPostWithTag.Tags.Add(tag);
+
+        var mockPosts = new List<Post> { postWithTag, anotherPostWithTag, postWithoutTag, unpublishedPostWithTag };
+
+        _mockCursor.Setup(_ => _.Current).Returns([postWithTag, anotherPostWithTag]);
+
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetPostsByTagAsync(tag);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.All(result, p => Assert.Contains(tag, p.Tags));
+        Assert.All(result, p => Assert.NotNull(p.PublishedAt));
+    }
+
+    [Fact]
+    public async Task GetPostsByTagAsync_Returns_Empty_When_NoMatchingTag()
+    {
+        // Arrange
+        var tag = "nonexistent-tag";
+        var mockPosts = new List<Post>(); // No matches
+
+        _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+        _mockCursor.Setup(_ => _.Current).Returns(mockPosts);
+
+        FilterDefinition<Post>? capturedFilter = null;
+
+        _mockCollection.Setup(c => c.FindAsync(
+            It.IsAny<FilterDefinition<Post>>(),
+            It.IsAny<FindOptions<Post, Post>>(),
+            It.IsAny<CancellationToken>()
+        )).Callback((FilterDefinition<Post> filter, FindOptions<Post, Post> _, CancellationToken _) =>
+        {
+            capturedFilter = filter;
+        }).ReturnsAsync(_mockCursor.Object);
+
+        // Act
+        var result = await _service.GetPostsByTagAsync(tag);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+
+
+        Assert.NotNull(capturedFilter);
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<Post>();
+        var renderedFilter = capturedFilter.Render(new RenderArgs<Post>(serializer, BsonSerializer.SerializerRegistry));
+
+        // Check that the filter contains the correct conditions
+        Assert.Equal(tag, renderedFilter["tags"].AsString); // Mongo driver is smart enough for elemMatch on simple equality
+        Assert.True(renderedFilter.Contains("published_at"));
+        Assert.Equal(BsonNull.Value, renderedFilter["published_at"].AsBsonDocument["$ne"]);
+
+    }
+}

--- a/Tests/Database/Mongo.cs
+++ b/Tests/Database/Mongo.cs
@@ -2,7 +2,7 @@ using Moq;
 using MongoDB.Driver;
 using Database.Mongo.Services;
 using Database.Mongo.Models;
-using Tests.Builders;
+using Tests.Builders.Mongo;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 

--- a/Tests/Database/Mongo.cs
+++ b/Tests/Database/Mongo.cs
@@ -3,6 +3,7 @@ using MongoDB.Driver;
 using Database.Mongo.Services;
 using Database.Mongo.Models;
 using Tests.Builders.Mongo;
+using Tests.Builders;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
@@ -51,8 +52,8 @@ public class MongoPostsServiceTests
     public async Task GetPublishedPostsAsync_Returns_OnlyPublishedPosts()
     {
         // Arrange
-        var publishedPost = new PostBuilder().IsPublished().Build();
-        var draftPost = new PostBuilder().IsDraft().Build();
+        var publishedPost = new Builders.Mongo.PostBuilder().IsPublished().Build();
+        var draftPost = new Builders.Mongo.PostBuilder().IsDraft().Build();
         var mockPosts = new List<Post> { publishedPost, draftPost };
 
         // Configure the cursor mock to return our mock data
@@ -99,7 +100,7 @@ public class MongoPostsServiceTests
     {
         // Arrange
         var expectedSlug = "published-post-slug";
-        var mockPost = new PostBuilder().IsPublished().WithSlug(expectedSlug).Build();
+        var mockPost = new Builders.Mongo.PostBuilder().IsPublished().WithSlug(expectedSlug).Build();
         _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(true)
             .ReturnsAsync(false);
@@ -141,7 +142,7 @@ public class MongoPostsServiceTests
     {
         // Arrange
         var slug = "draft-post";
-        var draftPost = new PostBuilder().IsDraft().WithSlug(slug).Build();
+        var draftPost = new Builders.Mongo.PostBuilder().IsDraft().WithSlug(slug).Build();
         // We configure the mock cursor to return no data
         _mockCursor.SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -192,23 +193,7 @@ public class MongoPostsServiceTests
     public async Task CreatePostAsync_Calls_InsertOneAsync()
     {
         // Arrange
-        var mockPost = new global::Database.Models.Post
-        {
-            Id = ObjectId.GenerateNewId().ToString(),
-            ArticleContent = "Test content",
-            Author = "Test Author",
-            Location = new global::Database.Models.Location
-            {
-                Id = ObjectId.GenerateNewId().ToString(),
-                Place = "Test City",
-                Latitude = 41.1561268114726,
-                Longitude = -81.41418385982185
-            },
-            ReadTimeMinutes = 5,
-            Slug = "test-title",
-            Summary = "Made to test the mongo service",
-            Title = "Test Title"
-        };
+        var mockPost = new Builders.PostBuilder().IsPublished().Build();
         var mongoPost = Post.FromCore(mockPost);
 
         // Configure the mock to do nothing when InsertOneAsync is called
@@ -235,23 +220,7 @@ public class MongoPostsServiceTests
     {
         // Arrange
         var mockId = ObjectId.GenerateNewId().ToString();
-        var mockPost = new global::Database.Models.Post
-        {
-            Id = mockId,
-            ArticleContent = "Test content",
-            Author = "Test Author",
-            Location = new global::Database.Models.Location
-            {
-                Id = ObjectId.GenerateNewId().ToString(),
-                Place = "Test City",
-                Latitude = 41.1561268114726,
-                Longitude = -81.41418385982185
-            },
-            ReadTimeMinutes = 5,
-            Slug = "test-title",
-            Summary = "Made to test the mongo service",
-            Title = "Test Title"
-        };
+        var mockPost = new Builders.PostBuilder().IsPublished().Build();
         var updatedMongoPost = Post.FromCore(mockPost);
 
         _mockCollection.Setup(c => c.ReplaceOneAsync(
@@ -322,10 +291,10 @@ public class MongoPostsServiceTests
     {
         // Arrange
         var tag = "photography";
-        var postWithTag = new PostBuilder().IsPublished().Build();
-        var anotherPostWithTag = new PostBuilder().IsPublished().WithSlug("another-post").Build();
-        var postWithoutTag = new PostBuilder().IsPublished().WithSlug("no-tag-post").Build(); // This one should be filtered out
-        var unpublishedPostWithTag = new PostBuilder().IsDraft().WithSlug("unpublished-post").Build(); // This one should be filtered out
+        var postWithTag = new Builders.Mongo.PostBuilder().IsPublished().Build();
+        var anotherPostWithTag = new Builders.Mongo.PostBuilder().IsPublished().WithSlug("another-post").Build();
+        var postWithoutTag = new Builders.Mongo.PostBuilder().IsPublished().WithSlug("no-tag-post").Build(); // This one should be filtered out
+        var unpublishedPostWithTag = new Builders.Mongo.PostBuilder().IsDraft().WithSlug("unpublished-post").Build(); // This one should be filtered out
         postWithTag.Tags.Add(tag);
         anotherPostWithTag.Tags.Add(tag);
         unpublishedPostWithTag.Tags.Add(tag);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/photographers_story_backend.sln
+++ b/photographers_story_backend.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
@@ -6,20 +7,54 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api", "Api\Api.csproj", "{C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{9CF47860-2CEA-F379-09D8-9AEF27965D12}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Database", "Database\Database.csproj", "{8D512EFB-17EF-4EC0-8F9A-88521856D890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Debug|x86.Build.0 = Debug|Any CPU
 		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|x64.Build.0 = Release|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBFA08EA-AECE-205F-7B85-326FD0B81BAD}.Release|x86.Build.0 = Release|Any CPU
 		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|x64.Build.0 = Debug|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Debug|x86.Build.0 = Debug|Any CPU
 		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|x64.ActiveCfg = Release|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|x64.Build.0 = Release|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|x86.ActiveCfg = Release|Any CPU
+		{9CF47860-2CEA-F379-09D8-9AEF27965D12}.Release|x86.Build.0 = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|x64.Build.0 = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Debug|x86.Build.0 = Debug|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|x64.ActiveCfg = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|x64.Build.0 = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|x86.ActiveCfg = Release|Any CPU
+		{8D512EFB-17EF-4EC0-8F9A-88521856D890}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### ⬆️ What does this PR add?

1. A Docker container for a MongoDB that facilitates local development without having to connect to AWS DynamoDB.
2. A database project for containing a service interface that allows consumers to use a DynamoDB connection in prod and a MongoDB container in local dev and staging.
3. An API endpoint for working with blog post data.
4. Tests for the mongo database service implementation.
5. Tests for the blog post API endpoint.

### ➡️ What does this PR change?

1. Update the workflows to spin up and tear down the Mongo container for each staging instance on the VPS.
2. Fixes the URI's from `/api/api/something` to `api/something`.